### PR TITLE
feat: CreateMatch UX 개선

### DIFF
--- a/src/features/createMatch/ui/ErrorFallback/MatchCreationErrorFallback.css.ts
+++ b/src/features/createMatch/ui/ErrorFallback/MatchCreationErrorFallback.css.ts
@@ -1,0 +1,10 @@
+import { style } from "@vanilla-extract/css"
+
+export const matchCreationErrorFallbackContainer = style({
+  textAlign: "center",
+})
+
+export const matchCreationErrorFallbackLottieWrapper = style({
+  width: "80%",
+  margin: "0 auto",
+})

--- a/src/features/createMatch/ui/ErrorFallback/MatchCreationErrorFallback.tsx
+++ b/src/features/createMatch/ui/ErrorFallback/MatchCreationErrorFallback.tsx
@@ -1,0 +1,59 @@
+import { DotLottieReact } from "@lottiefiles/dotlottie-react"
+import { useNavigate } from "react-router"
+import {
+  FormLayoutRoot,
+  FormLayoutHeader,
+  FormLayoutHeaderTitle,
+  FormLayoutHeaderDescription,
+  Button,
+  NavigationBar,
+  NavigationBarTitle,
+  NavigationBarBackButton,
+  FormLayoutButtonLayout,
+} from "@/shared/ui"
+import {
+  matchCreationErrorFallbackContainer,
+  matchCreationErrorFallbackLottieWrapper,
+} from "./MatchCreationErrorFallback.css"
+
+export default function MatchCreationErrorFallback() {
+  const navigate = useNavigate()
+
+  return (
+    <>
+      <NavigationBar>
+        <NavigationBarBackButton onClick={() => navigate("/")} />
+        <NavigationBarTitle>매치 등록 실패</NavigationBarTitle>
+      </NavigationBar>
+
+      <main className={matchCreationErrorFallbackContainer}>
+        <div className={matchCreationErrorFallbackLottieWrapper}>
+          <DotLottieReact
+            src="https://lottie.host/8e9d3c01-0931-4985-a4ee-9d9ad9f80083/HbabseOWvm.lottie"
+            loop
+            autoplay
+          />
+        </div>
+        <FormLayoutRoot>
+          <FormLayoutHeader>
+            <FormLayoutHeaderTitle>매치 등록에 실패했어요.</FormLayoutHeaderTitle>
+            <FormLayoutHeaderDescription>
+              일시적인 문제로 매치를 등록할 수 없었어요.
+              <br />
+              잠시 후 다시 시도해 주세요.
+            </FormLayoutHeaderDescription>
+          </FormLayoutHeader>
+
+          <FormLayoutButtonLayout>
+            <Button variant="primary" onClick={() => navigate("/create-team")}>
+              팀 생성하기
+            </Button>
+            <Button variant="terciary" onClick={() => navigate("/")}>
+              홈으로 이동
+            </Button>
+          </FormLayoutButtonLayout>
+        </FormLayoutRoot>
+      </main>
+    </>
+  )
+}

--- a/src/features/createMatch/ui/ErrorFallback/NoTeamFallback.css.ts
+++ b/src/features/createMatch/ui/ErrorFallback/NoTeamFallback.css.ts
@@ -1,0 +1,35 @@
+import { style } from "@vanilla-extract/css"
+import { spacing } from "@/shared/tokens"
+
+export const noTeamFallbackContainer = style({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  justifyContent: "center",
+  margin: `0 ${spacing[4]}`,
+})
+
+export const noTeamFallbackSection = style({
+  display: "flex",
+  flexDirection: "column",
+  textAlign: "center",
+  padding: spacing[4],
+  gap: spacing[2],
+  borderRadius: spacing[4],
+})
+
+export const noTeamFallbackLottieWrapper = style({
+  width: "80%",
+  margin: "0 auto",
+})
+
+export const noTeamFallbackButtonWrapper = style({
+  paddingTop: spacing[4],
+  display: "flex",
+  flexDirection: "column",
+  gap: spacing[2],
+})
+
+export const noTeamFallbackButton = style({
+  height: spacing[10],
+})

--- a/src/features/createMatch/ui/ErrorFallback/NoTeamFallback.tsx
+++ b/src/features/createMatch/ui/ErrorFallback/NoTeamFallback.tsx
@@ -1,0 +1,40 @@
+import { Link, useNavigate } from "react-router"
+import { DotLottieReact } from "@lottiefiles/dotlottie-react"
+import { Button, ErrorFallback, NavigationBar, NavigationBarBackButton } from "@/shared/ui"
+import {
+  noTeamFallbackContainer,
+  noTeamFallbackSection,
+  noTeamFallbackLottieWrapper,
+  noTeamFallbackButtonWrapper,
+  noTeamFallbackButton,
+} from "./NoTeamFallback.css"
+
+export default function NoTeamFallback() {
+  const navigate = useNavigate()
+
+  return (
+    <>
+      <NavigationBar>
+        <NavigationBarBackButton onClick={() => navigate(-1)} />
+      </NavigationBar>
+
+      <main className={noTeamFallbackContainer}>
+        <section className={noTeamFallbackSection}>
+          <div className={noTeamFallbackLottieWrapper}>
+            <DotLottieReact src="https://lottie.host/a99186c0-dd7d-4338-bdf9-43b926724af0/7fmvQ2NRkX.lottie" autoplay />
+          </div>
+          <ErrorFallback title="매치 등록은 팀이 있어야 가능해요." errorMessage="먼저 팀을 만들고 경기를 시작해보세요!">
+            <div className={noTeamFallbackButtonWrapper}>
+              <Button variant="primary" className={noTeamFallbackButton} asChild>
+                <Link to="/create-team">팀 생성하기</Link>
+              </Button>
+              <Button variant="terciary" className={noTeamFallbackButton} asChild>
+                <Link to="/">홈으로 이동</Link>
+              </Button>
+            </div>
+          </ErrorFallback>
+        </section>
+      </main>
+    </>
+  )
+}

--- a/src/features/createMatch/ui/Guard/CreateMatchGuard.tsx
+++ b/src/features/createMatch/ui/Guard/CreateMatchGuard.tsx
@@ -1,0 +1,20 @@
+import { ErrorBoundary } from "react-error-boundary"
+import { useTeamByOwnerId } from "@/entities/team"
+import { useAuthStore } from "@/shared/stores/authStore"
+import CreateMatchFunnel from "../form/CreateMatchFunnel"
+import MatchCreationErrorFallback from "../ErrorFallback/MatchCreationErrorFallback"
+
+export default function CreateMatchGuard() {
+  const { user } = useAuthStore()
+  const { data: teamData } = useTeamByOwnerId(user?.id ?? "")
+
+  if (!teamData) {
+    throw new Error("매치 등록은 팀이 있어야 가능해요.")
+  }
+
+  return (
+    <ErrorBoundary fallback={<MatchCreationErrorFallback />}>
+      <CreateMatchFunnel />
+    </ErrorBoundary>
+  )
+}

--- a/src/features/createMatch/ui/index.ts
+++ b/src/features/createMatch/ui/index.ts
@@ -1,1 +1,5 @@
 export { default as CreateMatchFunnel } from "./form/CreateMatchFunnel"
+export { default as CreateMatchGuard } from "./Guard/CreateMatchGuard"
+export { default as MatchCreationErrorFallback } from "./ErrorFallback/MatchCreationErrorFallback"
+export { default as NoTeamFallback } from "./ErrorFallback/NoTeamFallback"
+export { default as CreateMatchSkeleton } from "./skeleton/CreateMatchSkeleton"

--- a/src/features/createMatch/ui/skeleton/CreateMatchSkeleton.css.ts
+++ b/src/features/createMatch/ui/skeleton/CreateMatchSkeleton.css.ts
@@ -1,0 +1,48 @@
+import { style } from "@vanilla-extract/css"
+import { spacing } from "@/shared/tokens"
+
+export const createMatchSkeletonContainer = style({
+  margin: `0 ${spacing[4]}`,
+})
+
+export const createMatchSkeletonForm = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: spacing[4],
+  padding: spacing[4],
+})
+
+export const createMatchSkeletonFormSection = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: spacing[2],
+})
+
+export const createMatchSkeletonHeader = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: spacing[2],
+})
+
+export const createMatchSkeletonCalendar = style({
+  display: "grid",
+  gridTemplateColumns: "repeat(7, 1fr)",
+  gap: spacing[1],
+  marginBottom: spacing[3],
+})
+
+export const createMatchSkeletonTimeOptions = style({
+  display: "flex",
+  flexWrap: "wrap",
+  gap: spacing[2],
+})
+
+export const createMatchSkeletonTimeOption = style({
+  width: "60px",
+  height: "32px",
+  borderRadius: "16px",
+})
+
+export const createMatchSkeletonFieldWrapper = style({
+  padding: `${spacing[4]} 0`,
+})

--- a/src/features/createMatch/ui/skeleton/CreateMatchSkeleton.tsx
+++ b/src/features/createMatch/ui/skeleton/CreateMatchSkeleton.tsx
@@ -1,0 +1,63 @@
+import { NavigationBar, NavigationBarBackButton, NavigationBarTitle, Skeleton } from "@/shared/ui"
+import {
+  createMatchSkeletonContainer,
+  createMatchSkeletonForm,
+  createMatchSkeletonFormSection,
+  createMatchSkeletonHeader,
+  createMatchSkeletonCalendar,
+  createMatchSkeletonTimeOptions,
+  createMatchSkeletonTimeOption,
+  createMatchSkeletonFieldWrapper,
+} from "./CreateMatchSkeleton.css"
+
+export default function CreateMatchSkeleton() {
+  return (
+    <>
+      <NavigationBar>
+        <NavigationBarBackButton onClick={() => {}} />
+        <NavigationBarTitle>매치 등록하기</NavigationBarTitle>
+      </NavigationBar>
+
+      <main className={createMatchSkeletonContainer}>
+        <div className={createMatchSkeletonForm}>
+          <div className={createMatchSkeletonHeader}>
+            <Skeleton variant="title" width="80%" height="27px" />
+          </div>
+
+          <div className={createMatchSkeletonFormSection}>
+            <Skeleton variant="text" width="30%" height="16px" />
+
+            {/* Calendar skeleton */}
+            <div className={createMatchSkeletonCalendar}>
+              {/* Calendar header (요일) */}
+              {Array.from({ length: 7 }).map((_, index) => (
+                <Skeleton key={`header-${index}`} variant="text" width="100%" height="20px" />
+              ))}
+
+              {/* Calendar days */}
+              {Array.from({ length: 35 }).map((_, index) => (
+                <Skeleton key={`day-${index}`} variant="base" width="100%" height="32px" />
+              ))}
+            </div>
+
+            {/* Time options skeleton */}
+            <div className={createMatchSkeletonTimeOptions}>
+              {Array.from({ length: 6 }).map((_, index) => (
+                <Skeleton key={`time-${index}`} variant="base" className={createMatchSkeletonTimeOption} />
+              ))}
+            </div>
+          </div>
+
+          <div className={createMatchSkeletonFieldWrapper}>
+            <div className={createMatchSkeletonFormSection}>
+              <Skeleton variant="text" width="20%" height="16px" />
+              <Skeleton variant="input" width="100%" />
+            </div>
+          </div>
+
+          <Skeleton variant="button" width="100%" />
+        </div>
+      </main>
+    </>
+  )
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
#25 
> ex) #이슈번호, #이슈번호

## 📝작업 내용
- [x] CreateMatch 페이지 보호
- [x] CreateMatch 매치 등록 실패 시 에러 UI 보여주기
- [x] CreateMatch 스켈레톤 UI 구현

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

<img width="400" alt="image" src="https://github.com/user-attachments/assets/680156d4-967a-4c0c-af51-a2441bf83417" />
<img width="397" alt="image" src="https://github.com/user-attachments/assets/ceac3bfd-918e-483d-9218-1b7e72a5af48" />
<img width="398" alt="image" src="https://github.com/user-attachments/assets/45c92e59-23e3-4da6-8ee7-02cbf79b466b" />

