### PR TITLE
fix: [#31] MatchListPage 해당 날짜 데이터 패칭 에러

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,15 +32,14 @@ export default tseslint.config(
       "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
       "no-console": "warn",
       "no-debugger": "warn",
-      "no-unused-vars": "warn",
       "import/order": ["warn", { groups: ["builtin", "external", "internal"] }],
       "import/no-unresolved": "error",
       "import/no-extraneous-dependencies": "error",
       "unused-imports/no-unused-imports": "warn",
-      "unused-imports/no-unused-vars": ["warn", { vars: "all", varsIgnorePattern: "^_", argsIgnorePattern: "^_" }],
+      "unused-imports/no-unused-vars": ["error", { vars: "all", varsIgnorePattern: "^_", argsIgnorePattern: "^_" }],
       "no-unused-vars": "off",
       "@typescript-eslint/no-unused-vars": [
-        "warn",
+        "error",
         {
           argsIgnorePattern: "^_",
           varsIgnorePattern: "^_",

--- a/src/entities/match/match.apis.ts
+++ b/src/entities/match/match.apis.ts
@@ -1,11 +1,15 @@
+import { format, parse } from "date-fns"
 import { supabaseClient } from "@/shared/lib"
 import type { CreateMatchDto, Match, MatchDetail } from "./match.types"
 
-export async function fetchMatchList(): Promise<Match[] | null> {
+export async function getMatchList(selectedDate: string): Promise<Match[] | null> {
+  const formattedDate = format(parse(selectedDate.toString(), "dd", new Date()), "yyyy-MM-dd")
+
   return (
     await supabaseClient
       .from("matches")
       .select("*, teams(*), match_requests(*, teams(*))")
+      .eq("match_date", formattedDate)
       .order("match_time", { ascending: true })
   ).data
 }

--- a/src/entities/match/match.queryKeys.ts
+++ b/src/entities/match/match.queryKeys.ts
@@ -1,5 +1,5 @@
 export const matchKeys = {
   all: ["matchList"] as const,
-  list: () => [...matchKeys.all, "list"] as const,
+  list: (selectedDate: string | number) => [...matchKeys.all, "list", selectedDate] as const,
   detail: (matchId: string) => [...matchKeys.all, "detail", matchId] as const,
 }

--- a/src/entities/match/match.shemas.ts
+++ b/src/entities/match/match.shemas.ts
@@ -4,7 +4,7 @@ import { FOOTBALL_FIELD_NAMES, MATCH_FORMAT_OPTIONS, MATCH_TIME_OPTIONS } from "
 /** Base Schema */
 export const createMatchBaseSchema = z
   .object({
-    matchDate: z.string().min(1, "날짜를 선택해주세요."),
+    matchDate: z.date(),
     matchTime: z.enum(MATCH_TIME_OPTIONS),
     fieldName: z.enum(FOOTBALL_FIELD_NAMES),
     matchFormat: z.enum(MATCH_FORMAT_OPTIONS),

--- a/src/features/createMatch/lib/index.ts
+++ b/src/features/createMatch/lib/index.ts
@@ -3,7 +3,7 @@ import type { CreateMatchPayload } from "@/entities/match"
 
 export function transformCreateMatchToDto(data: CreateMatchPayload & { teamId: string }) {
   return {
-    match_date: data.matchDate,
+    match_date: format(data.matchDate, "yyyy-MM-dd"),
     match_time: convertTimeTo24Hour(data.matchTime),
     field_name: data.fieldName,
     match_format: data.matchFormat,

--- a/src/features/createMatch/ui/form/MatchDateTimeStep/MatchDateTimeStep.tsx
+++ b/src/features/createMatch/ui/form/MatchDateTimeStep/MatchDateTimeStep.tsx
@@ -1,7 +1,7 @@
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useCallback } from "react"
-import { format } from "date-fns"
+import { format, parse } from "date-fns"
 import {
   Badge,
   Button,
@@ -46,16 +46,17 @@ export default function MatchDateTimeStep({ onNext, onBack }: Props) {
   } = useForm({
     resolver: zodResolver(matchDateFormSchema),
     mode: "onTouched",
+    defaultValues: {
+      matchDate: parse(format(new Date(), "yyyy-MM-dd"), "yyyy-MM-dd", new Date()),
+    },
   })
 
   const { matchTime: selectedMatchTime } = watch()
 
-  const handleSelectMatchDate = useCallback(
-    (date: Date) => {
-      setValue("matchDate", format(date, "yyyy-MM-dd"), { shouldValidate: true })
-    },
-    [setValue]
-  )
+  const handleSelectMatchDate = (date: Date) => {
+    const parseDate = parse(format(date, "yyyy-MM-dd"), "yyyy-MM-dd", new Date())
+    setValue("matchDate", parseDate, { shouldValidate: true })
+  }
 
   const handleSelectFieldName = useCallback(
     (fieldName: FieldNameOption) => {

--- a/src/features/matchList/models/index.ts
+++ b/src/features/matchList/models/index.ts
@@ -1,2 +1,3 @@
 export * from "./useFetchMatchList"
 export * from "./useCreateMatchFlow"
+export * from "./useSelectedDate"

--- a/src/features/matchList/models/useCreateMatchFlow.ts
+++ b/src/features/matchList/models/useCreateMatchFlow.ts
@@ -1,4 +1,3 @@
-import { useNavigate } from "react-router"
 import { useState } from "react"
 import { useAuthStore } from "@/shared/stores/authStore"
 
@@ -7,7 +6,6 @@ import { REQUIRED_MODAL_TYPE } from "@/entities/match"
 import { useTeamByOwnerId } from "@/entities/team"
 
 export function useCreateMatchFlow() {
-  const navigate = useNavigate()
   const [modalType, setModalType] = useState<RequiredModalType | null>(null)
 
   const { user } = useAuthStore()
@@ -23,8 +21,6 @@ export function useCreateMatchFlow() {
       setModalType(REQUIRED_MODAL_TYPE.TEAM)
       return
     }
-
-    navigate("/create-match")
   }
 
   return { modalType, handleProtectedFlow }

--- a/src/features/matchList/models/useFetchMatchList.tsx
+++ b/src/features/matchList/models/useFetchMatchList.tsx
@@ -1,9 +1,9 @@
 import { useSuspenseQuery } from "@tanstack/react-query"
-import { fetchMatchList, matchKeys } from "@/entities/match"
+import { getMatchList, matchKeys } from "@/entities/match"
 
-export function useFetchMatchList() {
+export function useFetchMatchList(selectedDate: string) {
   return useSuspenseQuery({
-    queryKey: matchKeys.list(),
-    queryFn: fetchMatchList,
+    queryKey: matchKeys.list(selectedDate),
+    queryFn: () => getMatchList(selectedDate),
   })
 }

--- a/src/features/matchList/models/useSelectedDate.ts
+++ b/src/features/matchList/models/useSelectedDate.ts
@@ -1,0 +1,21 @@
+import { format, parse } from "date-fns"
+import { useState } from "react"
+
+interface Params {
+  initialDate?: Date
+}
+
+export function useSelectedDate({ initialDate }: Params = {}) {
+  const [selectedDate, setSelectedDate] = useState(
+    initialDate || parse(format(new Date(), "yyyy-MM-dd"), "yyyy-MM-dd", new Date())
+  )
+
+  const selectedDateChange = (date: Date) => {
+    setSelectedDate(date)
+  }
+
+  return {
+    selectedDate,
+    selectedDateChange,
+  }
+}

--- a/src/features/matchList/ui/CreateMatchButton/CreateMatchButton.tsx
+++ b/src/features/matchList/ui/CreateMatchButton/CreateMatchButton.tsx
@@ -1,4 +1,6 @@
 import clsx from "clsx"
+import { format, parse } from "date-fns"
+import { useNavigate, useSearchParams } from "react-router"
 import { useCreateMatchFlow } from "@/features/matchList/models"
 import { Button } from "@/shared/ui"
 import { useToggle } from "@/shared/hooks"
@@ -10,12 +12,24 @@ interface Props {
 }
 
 export default function CreateMatchButton({ className }: Props) {
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
   const { isOpen, open, setOpen } = useToggle()
   const { modalType, handleProtectedFlow } = useCreateMatchFlow()
 
   const handleModalClick = () => {
     open()
-    handleProtectedFlow()
+
+    if (modalType) {
+      handleProtectedFlow()
+      return
+    }
+
+    const initialDate = searchParams.get("day")
+      ? parse(searchParams.get("day")!, "dd", new Date())
+      : parse(format(new Date(), "yyyy-MM-dd"), "yyyy-MM-dd", new Date())
+
+    navigate(`/create-match?day=${format(initialDate, "dd")}`)
   }
 
   return (

--- a/src/features/matchList/ui/MatchList/MatchList.tsx
+++ b/src/features/matchList/ui/MatchList/MatchList.tsx
@@ -4,8 +4,12 @@ import MatchListItem from "./MatchListItem"
 import { useFetchMatchList } from "../../models"
 import CreateMatchButton from "../CreateMatchButton/CreateMatchButton"
 
-export default function MatchList() {
-  const { data: matchList } = useFetchMatchList()
+interface Props {
+  selectedDay: string
+}
+
+export default function MatchList({ selectedDay }: Props) {
+  const { data: matchList } = useFetchMatchList(selectedDay)
 
   if (matchList?.length === 0) {
     return <EmptyMatchList />

--- a/src/pages/MatchListPage/MatchListPage.tsx
+++ b/src/pages/MatchListPage/MatchListPage.tsx
@@ -1,6 +1,8 @@
 import { ErrorBoundary } from "react-error-boundary"
 import { Suspense } from "react"
 import { useQueryErrorResetBoundary } from "@tanstack/react-query"
+import { format, parse } from "date-fns"
+import { useSearchParams } from "react-router"
 import {
   MatchListBanner,
   MatchList,
@@ -9,16 +11,25 @@ import {
   MatchListErrorFallback,
 } from "@/features/matchList/ui"
 import { Header, MonthlyCalendar } from "@/shared/ui"
+import { useSelectedDate } from "@/features/matchList/models"
 
 export default function MatchListPage() {
+  const [searchParams] = useSearchParams()
+
+  const initialDate = searchParams.get("day")
+    ? parse(searchParams.get("day")!, "dd", new Date())
+    : parse(format(new Date(), "yyyy-MM-dd"), "yyyy-MM-dd", new Date())
+
+  const { selectedDate, selectedDateChange } = useSelectedDate({ initialDate })
   const { reset } = useQueryErrorResetBoundary()
+  const selectedDay = format(selectedDate, "dd")
 
   return (
     <>
       <Header />
       <main>
         <MatchListBanner />
-        <MonthlyCalendar />
+        <MonthlyCalendar defaultValue={selectedDate} onValueChange={selectedDateChange} />
         <CreateMatchButton />
         <ErrorBoundary
           onReset={reset}
@@ -27,7 +38,7 @@ export default function MatchListPage() {
           }}
         >
           <Suspense fallback={<MatchListSkeleton />}>
-            <MatchList />
+            <MatchList selectedDay={selectedDay} />
           </Suspense>
         </ErrorBoundary>
       </main>

--- a/src/shared/ui/Calendar/DayCell/DayCell.tsx
+++ b/src/shared/ui/Calendar/DayCell/DayCell.tsx
@@ -1,4 +1,5 @@
-import { isSameDay } from "date-fns"
+import { format, isSameDay } from "date-fns"
+import { useNavigate } from "react-router"
 import { dayCell, dayNumberStyle, weekdayStyle } from "./DayCell.css"
 import type { DayCellVariantType } from "./DayCell.type"
 import { getDayName, getDayNumber } from "../utils"
@@ -6,18 +7,24 @@ import { getDayName, getDayNumber } from "../utils"
 interface Props {
   date: Date
   selected: boolean
-  // eslint-disable-next-line no-unused-vars
   onSelected: (date: Date) => void
 }
 
 export default function DayCell({ date, selected, onSelected }: Props) {
+  const navigate = useNavigate()
   const dayName = getDayName(date)
   const dayNumber = getDayNumber(date, { isPad: true })
   const isToday = isSameDay(new Date(), date)
+
   const variant: DayCellVariantType = selected ? "selected" : isToday ? "current" : "default"
 
+  const handleSelectedDay = (date: Date) => {
+    onSelected(date)
+    navigate(`?day=${format(date, "dd")}`)
+  }
+
   return (
-    <button className={dayCell({ variant })} onClick={() => onSelected(date)}>
+    <button type="button" className={dayCell({ variant })} onClick={() => handleSelectedDay(date)}>
       <div className={selected ? weekdayStyle.selected : weekdayStyle.unselected}>{dayName}</div>
       <div className={selected ? dayNumberStyle.selected : dayNumberStyle.unselected}>{dayNumber}</div>
     </button>

--- a/src/shared/ui/Calendar/MonthlyCalender/MonthlyCalender.tsx
+++ b/src/shared/ui/Calendar/MonthlyCalender/MonthlyCalender.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useState } from "react"
 import { format, parse } from "date-fns"
 import { Swiper, SwiperSlide } from "swiper/react"
 import { clsx } from "clsx"
+import { useMemo } from "react"
+import { useSearchParams } from "react-router"
+import { useControllableState } from "@/shared/hooks"
 import { getRemainingDaysOfMonth } from "../utils"
 import DayCell from "../DayCell/DayCell"
 
@@ -9,24 +11,31 @@ import { swiperContainer, dayCellSlide, swiperWrapper } from "./MonthlyCalender.
 
 interface Props {
   swiperContainerClassName?: string
+  defaultValue?: Date
   onValueChange?: (date: Date) => void
 }
 
-export default function MonthlyCalendar({ swiperContainerClassName, onValueChange }: Props) {
-  const today = new Date()
-  const [selectedDate, setSelectedDate] = useState<string>(format(today, "yyyy-MM-dd"))
+export default function MonthlyCalendar({ swiperContainerClassName, onValueChange, defaultValue }: Props) {
+  const [searchParams] = useSearchParams()
+
+  const today = useMemo(() => new Date(), [])
   const remainingDays = getRemainingDaysOfMonth(today)
 
-  const handleSelectedDate = (date: Date) => {
-    setSelectedDate(format(date, "yyyy-MM-dd"))
-    onValueChange?.(date)
-  }
+  const initialDate = searchParams.get("day")
+    ? parse(searchParams.get("day")!, "dd", new Date())
+    : parse(format(today, "yyyy-MM-dd"), "yyyy-MM-dd", new Date())
 
-  useEffect(() => {
-    if (onValueChange) {
-      onValueChange(parse(selectedDate, "yyyy-MM-dd", new Date()))
-    }
-  }, [selectedDate, onValueChange])
+  const [selectedDate, setSelectedDate] = useControllableState({
+    prop: defaultValue,
+    defaultProp: defaultValue ?? initialDate,
+    onChange: onValueChange,
+  })
+
+  console.log(searchParams.get("day"))
+
+  const handleSelectedDate = (date: Date) => {
+    setSelectedDate(parse(format(date, "yyyy-MM-dd"), "yyyy-MM-dd", new Date()))
+  }
 
   return (
     <Swiper


### PR DESCRIPTION
## #️⃣연관된 이슈
#31
> ex) #이슈번호, #이슈번호

## 📝작업 내용

1. 매치 리스트 데이터가 모두 불러와지는 문제:
- Given: 사용자가 MatchListPage를 열고 오늘 날짜에 해당하는 매치만 불러오길 원함.
- When: 페이지가 로드되거나 날짜를 선택했을 때, 날짜 필터링 조건이 제대로 작동하지 않고 모든 매치가 불러와짐.
- Then: 서버에서 날짜 필터링이 올바르게 동작하지 않아서, 모든 매치가 로드된다. (오늘 날짜에 해당하는 매치만 필터링되어야 함)

2. 날짜 선택 후 데이터 변경되지 않는 문제:
- Given: 사용자가 날짜를 선택한다.
- When: 날짜를 선택했을 때, 서버 호출이 발생하지 않음.
- Then: 선택된 날짜에 맞는 매치 리스트가 업데이트되지 않음. 서버 호출이 제대로 발생하지 않아 데이터가 변경되지 않는다.

3. 매치 리스트 페이지에서 오늘 날짜가 아닌, 다른 날로 선택한 후, 매치 등록하기를 눌렀을 때 해당 날짜로 기본값이 설정되지 않음.

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)
